### PR TITLE
Fix `ansible-local` plugin registration

### DIFF
--- a/example/docker-ansible-local.pkr.hcl
+++ b/example/docker-ansible-local.pkr.hcl
@@ -1,0 +1,21 @@
+variable "topping" {
+  type    = string
+  default = "mushroom"
+}
+
+source "docker" "example" {
+  image       = "williamyeh/ansible:ubuntu14.04"
+  export_path = "packer_example"
+  run_command = ["-d", "-i", "-t", "--entrypoint=/bin/bash", "{{.Image}}"]
+}
+
+build {
+  sources = [
+    "source.docker.example"
+  ]
+
+  provisioner "ansible-local" {
+    playbook_file   = "./local-playbook.yml"
+    extra_arguments = ["--extra-vars", "\"pizza_toppings=${var.topping}\""]
+  }
+}

--- a/example/local-playbook.yml
+++ b/example/local-playbook.yml
@@ -1,0 +1,9 @@
+---
+- name: hello world
+  hosts: 127.0.0.1
+  connection: local
+
+  tasks:
+    - command: echo {{ pizza_toppings }}
+    - debug: msg="{{ pizza_toppings }}"
+

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var (
 func main() {
 	pps := plugin.NewSet()
 	pps.RegisterProvisioner(plugin.DEFAULT_NAME, new(ansible.Provisioner))
-	pps.RegisterProvisioner("ansible-local", new(ansibleLocal.Provisioner))
+	pps.RegisterProvisioner("local", new(ansibleLocal.Provisioner))
 	pps.SetVersion(PluginVersion)
 	err := pps.Run()
 


### PR DESCRIPTION
Before change
```
Error: Unknown provisioner type "ansible-local"
2021/05/11 10:43:56 [INFO] (telemetry) Finalizing.

  on ansible_local_docker.pkr.hcl line 17:
  (source code not available)

known provisioners: [ansible-ansible-local azure-azure-dtlartifact breakpoint
shell puppet-puppet-masterless scaffolding scaffolding-ansible-local ansible
chef-client powershell windows-shell sleep chef-chef-client chef-chef-solo
converge windows-restart shell-local puppet-masterless file puppet-server
chef-solo puppet-puppet-server salt-masterless azure-dtlartifact inspec]
```

After changes
```
    docker.example: Executing Ansible: cd /tmp/packer-provisioner-ansible-local/609a99da-7d63-d70b-6761-21607d741553 && ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 ansible-playbook /tmp/packer-provisioner-ansible-local/609a99da-7d63-d70b-6761-21607d741553/local-playbook.yml --extra-vars "packer_build_name=example packer_builder_type=docker packer_http_addr=ERR_HTTP_ADDR_NOT_IMPLEMENTED_BY_BUILDER -o IdentitiesOnly=yes" --extra-vars "pizza_toppings=mushroom" -c local -i /tmp/packer-provisioner-ansible-local/609a99da-7d63-d70b-6761-21607d741553/packer-provisioner-ansible-local672857214
    docker.example:
    docker.example: PLAY [hello world] *************************************************************
    docker.example:
    docker.example: TASK [Gathering Facts] *********************************************************
    docker.example: ok: [127.0.0.1]
    docker.example:
    docker.example: TASK [command] *****************************************************************
    docker.example: changed: [127.0.0.1]
    docker.example:
    docker.example: TASK [debug] *******************************************************************
    docker.example: ok: [127.0.0.1] => {
    docker.example:     "msg": "mushroom"
    docker.example: }
    docker.example:
    docker.example: PLAY RECAP *********************************************************************
    docker.example: 127.0.0.1                  : ok=3    changed=1    unreachable=0    failed=0
    docker.example:
==> docker.example: Exporting the container
==> docker.example: Killing the container: cbc5638537f66a21dc3ca6ccd604bf2a27b8698bf0fd71f84f7a56c869f00b22
Build 'docker.example' finished after 8 seconds 130 milliseconds.
```
