### PR TITLE
Add go mod retractions for versions: v0.0.1, v0.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 main
 dist/*
 docs-rendered/*
-packer-plugin-scaffolding
+packer-plugin-ansible

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,6 @@ require (
 	github.com/zclconf/go-cty v1.8.3
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 )
+
+// Incorrect plugin registration for ansible-local; see packer-plugin-ansible/pull/44
+retract [v0.0.1, v0.0.2]


### PR DESCRIPTION
This changes marks the referenced versions as unusable. The retract directive does not prevent the versions from being used but it will notify consumers that the version has been marked as unusable and encourage the consumer to upgrade. 

Current available versions
```
~>  go list -versions -m github.com/hashicorp/packer-plugin-ansible
github.com/hashicorp/packer-plugin-ansible v0.0.1 v0.0.2 v0.0.3
```

Once merged listing available version should look something like
```
~>  go list -versions -m github.com/hashicorp/packer-plugin-ansible
github.com/hashicorp/packer-plugin-ansible v0.0.3
```