### PR TITLE
Fix documentation for ansible-local provider

### DIFF
--- a/docs/provisioners/ansible-local.mdx
+++ b/docs/provisioners/ansible-local.mdx
@@ -110,7 +110,7 @@ The reference of available configuration options is listed below.
 
 Note that one of `playbook_file` or `playbook_files` is required.
 
-@include '/provisioner/ansible/Config-not-required.mdx'
+@include '/provisioner/ansible-local/Config-not-required.mdx'
 
 @include 'provisioners/common-config.mdx'
 


### PR DESCRIPTION
`ansible-local` provider documentation is showing `ansible` provider configuration attributes instead of `ansible-local` ones.
