### PR TITLE
update ansible docs to remove references to WinRMPassword 

### DIFF
--- a/docs-partials/provisioner/ansible-local/Config-not-required.mdx
+++ b/docs-partials/provisioner/ansible-local/Config-not-required.mdx
@@ -13,8 +13,9 @@
   not be quoted. Usage example:
   
   ```json
-    "extra_arguments": [ "--extra-vars", "Region={{user `Region`}} Stage={{user `Stage`}}" ]
+     "extra_arguments": [ "--extra-vars", "Region={{user `Region`}} Stage={{user `Stage`}}" ]
   ```
+  
   In certain scenarios where you want to pass ansible command line arguments
   that include parameter and value (for example `--vault-password-file pwfile`),
   from ansible documentation this is correct format but that is NOT accepted here.
@@ -23,12 +24,23 @@
   If you are running a Windows build on AWS, Azure, Google Compute, or OpenStack
   and would like to access the auto-generated password that Packer uses to
   connect to a Windows instance via WinRM, you can use the template variable
-  `{{.WinRMPassword}}` in this option. For example:
+  
+  ```build.Password``` in HCL templates or ```{{ build `Password`}}``` in
+  legacy JSON templates. For example:
+  
+  in JSON templates:
   
   ```json
-    "extra_arguments": [
-      "--extra-vars", "winrm_password={{ .WinRMPassword }}"
-    ]
+  "extra_arguments": [
+     "--extra-vars", "winrm_password={{ build `Password`}}"
+  ]
+  ```
+  
+  in HCL templates:
+  ```hcl
+  extra_arguments = [
+     "--extra-vars", "winrm_password=${build.Password}"
+  ]
   ```
 
 - `group_vars` (string) - A path to the directory containing ansible group

--- a/docs-partials/provisioner/ansible/Config-not-required.mdx
+++ b/docs-partials/provisioner/ansible/Config-not-required.mdx
@@ -13,8 +13,9 @@
   not be quoted. Usage example:
   
   ```json
-    "extra_arguments": [ "--extra-vars", "Region={{user `Region`}} Stage={{user `Stage`}}" ]
+     "extra_arguments": [ "--extra-vars", "Region={{user `Region`}} Stage={{user `Stage`}}" ]
   ```
+  
   In certain scenarios where you want to pass ansible command line arguments
   that include parameter and value (for example `--vault-password-file pwfile`),
   from ansible documentation this is correct format but that is NOT accepted here.
@@ -23,12 +24,23 @@
   If you are running a Windows build on AWS, Azure, Google Compute, or OpenStack
   and would like to access the auto-generated password that Packer uses to
   connect to a Windows instance via WinRM, you can use the template variable
-  `{{.WinRMPassword}}` in this option. For example:
+  
+  ```build.Password``` in HCL templates or ```{{ build `Password`}}``` in
+  legacy JSON templates. For example:
+  
+  in JSON templates:
   
   ```json
-    "extra_arguments": [
-      "--extra-vars", "winrm_password={{ .WinRMPassword }}"
-    ]
+  "extra_arguments": [
+     "--extra-vars", "winrm_password={{ build `Password`}}"
+  ]
+  ```
+  
+  in HCL templates:
+  ```hcl
+  extra_arguments = [
+     "--extra-vars", "winrm_password=${build.Password}"
+  ]
   ```
 
 - `ansible_env_vars` ([]string) - Environment variables to set before

--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -37,8 +37,9 @@ type Config struct {
 	// not be quoted. Usage example:
 	//
 	// ```json
-	//   "extra_arguments": [ "--extra-vars", "Region={{user `Region`}} Stage={{user `Stage`}}" ]
+	//    "extra_arguments": [ "--extra-vars", "Region={{user `Region`}} Stage={{user `Stage`}}" ]
 	// ```
+	//
 	// In certain scenarios where you want to pass ansible command line arguments
 	// that include parameter and value (for example `--vault-password-file pwfile`),
 	// from ansible documentation this is correct format but that is NOT accepted here.
@@ -47,12 +48,23 @@ type Config struct {
 	// If you are running a Windows build on AWS, Azure, Google Compute, or OpenStack
 	// and would like to access the auto-generated password that Packer uses to
 	// connect to a Windows instance via WinRM, you can use the template variable
-	// `{{.WinRMPassword}}` in this option. For example:
+	//
+	// ```build.Password``` in HCL templates or ```{{ build `Password`}}``` in
+	// legacy JSON templates. For example:
+	//
+	// in JSON templates:
 	//
 	// ```json
-	//   "extra_arguments": [
-	//     "--extra-vars", "winrm_password={{ .WinRMPassword }}"
-	//   ]
+	// "extra_arguments": [
+	//    "--extra-vars", "winrm_password={{ build `Password`}}"
+	// ]
+	// ```
+	//
+	// in HCL templates:
+	// ```hcl
+	// extra_arguments = [
+	//    "--extra-vars", "winrm_password=${build.Password}"
+	// ]
 	// ```
 	ExtraArguments []string `mapstructure:"extra_arguments"`
 	// A path to the directory containing ansible group

--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -55,8 +55,9 @@ type Config struct {
 	// not be quoted. Usage example:
 	//
 	// ```json
-	//   "extra_arguments": [ "--extra-vars", "Region={{user `Region`}} Stage={{user `Stage`}}" ]
+	//    "extra_arguments": [ "--extra-vars", "Region={{user `Region`}} Stage={{user `Stage`}}" ]
 	// ```
+	//
 	// In certain scenarios where you want to pass ansible command line arguments
 	// that include parameter and value (for example `--vault-password-file pwfile`),
 	// from ansible documentation this is correct format but that is NOT accepted here.
@@ -65,12 +66,23 @@ type Config struct {
 	// If you are running a Windows build on AWS, Azure, Google Compute, or OpenStack
 	// and would like to access the auto-generated password that Packer uses to
 	// connect to a Windows instance via WinRM, you can use the template variable
-	// `{{.WinRMPassword}}` in this option. For example:
+	//
+	// ```build.Password``` in HCL templates or ```{{ build `Password`}}``` in
+	// legacy JSON templates. For example:
+	//
+	// in JSON templates:
 	//
 	// ```json
-	//   "extra_arguments": [
-	//     "--extra-vars", "winrm_password={{ .WinRMPassword }}"
-	//   ]
+	// "extra_arguments": [
+	//    "--extra-vars", "winrm_password={{ build `Password`}}"
+	// ]
+	// ```
+	//
+	// in HCL templates:
+	// ```hcl
+	// extra_arguments = [
+	//    "--extra-vars", "winrm_password=${build.Password}"
+	// ]
 	// ```
 	ExtraArguments []string `mapstructure:"extra_arguments"`
 	// Environment variables to set before


### PR DESCRIPTION
WinRMPassword is deprecated in favor of `${build.Password}` and {{build `Password`}}
Fixes #56