### PR TITLE
docs: Fix small typo

### DIFF
--- a/docs/provisioners/ansible.mdx
+++ b/docs/provisioners/ansible.mdx
@@ -801,6 +801,6 @@ build {
 
 If you are using an Ansible version >= 2.8 and Packer hangs in the
 "Gathering Facts" stage, this could be the result of a pipelineing issue with
-the proxy adapter that Packer uses. Setting `use_proxy: false,` in your
+the proxy adapter that Packer uses. Setting `use_proxy: false` in your
 Packer config should resolve the issue. In the future we will default to setting
 this, so you won't have to but for now it is a manual change you must make.

--- a/docs/provisioners/ansible.mdx
+++ b/docs/provisioners/ansible.mdx
@@ -801,6 +801,6 @@ build {
 
 If you are using an Ansible version >= 2.8 and Packer hangs in the
 "Gathering Facts" stage, this could be the result of a pipelineing issue with
-the proxy adapter that Packer uses. Setting `use_proxy: false` in your
+the proxy adapter that Packer uses. Setting `set_proxy` to `false` in your
 Packer config should resolve the issue. In the future we will default to setting
 this, so you won't have to but for now it is a manual change you must make.


### PR DESCRIPTION
Fix a minimal typo in the documentation.