### PR TITLE
sed s/ubuntu/windows/

### DIFF
--- a/docs/provisioners/ansible.mdx
+++ b/docs/provisioners/ansible.mdx
@@ -247,11 +247,11 @@ Below is a fully functioning Ansible example using WinRM:
 <Tab heading="HCL2">
 
 ```hcl
-data "amazon-ami" "ubuntu" {
+data "amazon-ami" "windows" {
   access_key = var.aws_access_key
 
   filters = {
-    name                = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
+    name                = "*Windows_Server-2012*English-64Bit-Base*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }


### PR DESCRIPTION
json and hcl2 examples have different values for WinRM, which appears to be an oversight/copy+paste error.