### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/docs-partials/provisioner/ansible/Config-not-required.mdx
+++ b/docs-partials/provisioner/ansible/Config-not-required.mdx
@@ -50,7 +50,7 @@
       "ansible_env_vars": [ "ANSIBLE_HOST_KEY_CHECKING=False", "ANSIBLE_SSH_ARGS='-o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s'", "ANSIBLE_NOCOLOR=True" ]
     ```
   
-    This is a [template engine](/docs/templates/legacy_json_templates/engine). Therefore, you
+    This is a [template engine](/packer/docs/templates/legacy_json_templates/engine). Therefore, you
     may use user variables and template functions in this field.
   
     For example, if you are running a Windows build on AWS, Azure,

--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -92,7 +92,7 @@ type Config struct {
 	//     "ansible_env_vars": [ "ANSIBLE_HOST_KEY_CHECKING=False", "ANSIBLE_SSH_ARGS='-o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s'", "ANSIBLE_NOCOLOR=True" ]
 	//   ```
 	//
-	//   This is a [template engine](/docs/templates/legacy_json_templates/engine). Therefore, you
+	//   This is a [template engine](/packer/docs/templates/legacy_json_templates/engine). Therefore, you
 	//   may use user variables and template functions in this field.
 	//
 	//   For example, if you are running a Windows build on AWS, Azure,


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them
