### PR TITLE
docs: fix link to packer docs

### DIFF
--- a/docs/provisioners/ansible-local.mdx
+++ b/docs/provisioners/ansible-local.mdx
@@ -24,7 +24,7 @@ via the `ansible-playbook` command.
 -> **Note:** Ansible will _not_ be installed automatically by this
 provisioner. This provisioner expects that Ansible is already installed on the
 guest/remote machine. It is common practice to use the [shell
-provisioner](/docs/provisioners/shell) before the Ansible provisioner to
+provisioner](/packer/docs/provisioners/shell) before the Ansible provisioner to
 do this.
 
 ## Basic Example


### PR DESCRIPTION
The last PR forgot to update a link for the new dev site, this PR fixes this.