### PR TITLE
Build plugin for illumos.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,6 +69,7 @@ builds:
       - openbsd
       - freebsd
       - windows
+      - illumos
       - solaris
     goarch:
       - amd64
@@ -77,6 +78,10 @@ builds:
     ignore:
       - goos: windows
         goarch: arm
+      - goos: illumos
+        goarch: arm
+      - goos: illumos
+        goarch: '386'
       - goos: solaris
         goarch: arm
       - goos: solaris


### PR DESCRIPTION
This hopefully results in illumos binaries being made available, currently the experience is:

```shell
$ packer init -upgrade .
Failed getting the "github.com/hashicorp/ansible" plugin:
15 errors occurred:
        * ignoring invalid remote binary packer-plugin-ansible_v1.0.3_x5.0_freebsd_arm64.zip: wrong system, expected illumos_amd64 
[...]
        * could not install any compatible version of plugin "github.com/hashicorp/ansible"
```

Many thanks.