### PR TITLE
docs: fix typo in parameter name for troubleshooting section

### DIFF
--- a/docs/provisioners/ansible.mdx
+++ b/docs/provisioners/ansible.mdx
@@ -801,6 +801,7 @@ build {
 
 If you are using an Ansible version >= 2.8 and Packer hangs in the
 "Gathering Facts" stage, this could be the result of a pipelineing issue with
-the proxy adapter that Packer uses. Setting `set_proxy` to `false` in your
-Packer config should resolve the issue. In the future we will default to setting
-this, so you won't have to but for now it is a manual change you must make.
+the proxy adapter that Packer uses. Setting `use_proxy` to `false` in the ansible
+provisioner block of your Packer config should resolve the issue. In the future 
+we will default to setting this, so you won't have to but for now it is a manual 
+change you must make.


### PR DESCRIPTION
updating docs to reflect the correct parameter name and where it should be set

should be `use_proxy`, not `set_proxy` 

resolves: https://github.com/hashicorp/packer-plugin-ansible/issues/148
