### PR TITLE
Fix missing space between ssh extra args

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -774,11 +774,7 @@ func (p *Provisioner) createCmdArgs(httpAddr, inventory, playbook, privKeyFile s
 	if p.generatedData["ConnType"] == "ssh" && len(privKeyFile) > 0 {
 		// Add ssh extra args to set IdentitiesOnly
 		if len(p.config.AnsibleSSHExtraArgs) > 0 {
-			var sshExtraArgs string
-			for _, sshExtraArg := range p.config.AnsibleSSHExtraArgs {
-				sshExtraArgs = sshExtraArgs + sshExtraArg
-			}
-			args = append(args, "--ssh-extra-args", fmt.Sprintf("'%s'", sshExtraArgs))
+			args = append(args, "--ssh-extra-args", strings.Join(p.config.AnsibleSSHExtraArgs, " "))
 		} else {
 			args = append(args, "--ssh-extra-args", "'-o IdentitiesOnly=yes'")
 		}

--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -774,7 +774,7 @@ func (p *Provisioner) createCmdArgs(httpAddr, inventory, playbook, privKeyFile s
 	if p.generatedData["ConnType"] == "ssh" && len(privKeyFile) > 0 {
 		// Add ssh extra args to set IdentitiesOnly
 		if len(p.config.AnsibleSSHExtraArgs) > 0 {
-			args = append(args, "--ssh-extra-args", strings.Join(p.config.AnsibleSSHExtraArgs, " "))
+			args = append(args, "--ssh-extra-args", "'" + strings.Join(p.config.AnsibleSSHExtraArgs, " ") + "'")
 		} else {
 			args = append(args, "--ssh-extra-args", "'-o IdentitiesOnly=yes'")
 		}

--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -774,7 +774,7 @@ func (p *Provisioner) createCmdArgs(httpAddr, inventory, playbook, privKeyFile s
 	if p.generatedData["ConnType"] == "ssh" && len(privKeyFile) > 0 {
 		// Add ssh extra args to set IdentitiesOnly
 		if len(p.config.AnsibleSSHExtraArgs) > 0 {
-			args = append(args, "--ssh-extra-args", "'" + strings.Join(p.config.AnsibleSSHExtraArgs, " ") + "'")
+			args = append(args, "--ssh-extra-args", fmt.Sprintf("'%s'", strings.Join(p.config.AnsibleSSHExtraArgs, " ")))
 		} else {
 			args = append(args, "--ssh-extra-args", "'-o IdentitiesOnly=yes'")
 		}


### PR DESCRIPTION
Hi,

When passing more than one ssh extra arg, they are concatenated without a space between them.

Using strings.Join fixes the issue.

Closes #116
