### PR TITLE
docs: remove misconstructed tabs

### DIFF
--- a/docs/provisioners/ansible.mdx
+++ b/docs/provisioners/ansible.mdx
@@ -243,9 +243,6 @@ extra_arguments.
 
 Below is a fully functioning Ansible example for amazon-ebs using WinRM:
 
-<Tabs>
-<Tab heading="HCL2">
-
 ```hcl
 
 variable "aws_region"{
@@ -308,8 +305,6 @@ build {
     }
 }
 ```
-
-</Tab>
 
 Below is a fully functioning Ansible example for azure-arm using WinRM.
 Note: pywinrm needs to be installed into the python environment on your local build machine if it's not already installed.


### PR DESCRIPTION
In the documentation for the remote ansible provisioner, a misconstructed Tabs was added in between release v1.0.3 and v1.0.4.

In effect, this prevented the documentation from being generated again, and made previewing docs impossible on Packer.

This commit removes the mismatched Tabs since there's only an HCL2 template specified, therefore there's no need for Tabs here.