### PR TITLE
adapter: use ECDSA keys for adapter instead of RSA

### DIFF
--- a/docs-partials/provisioner/ansible/Config-not-required.mdx
+++ b/docs-partials/provisioner/ansible/Config-not-required.mdx
@@ -97,6 +97,16 @@
    this key is generated, the corresponding private key is passed to
    `ansible-playbook` with the `-e ansible_ssh_private_key_file` option.
 
+- `ansible_proxy_key_type` (string) - Change the key type used for the adapter.
+  
+  Supported values:
+  
+  * ECDSA (default)
+  * RSA
+  
+  NOTE: using RSA may cause problems if the key is used to authenticate with rsa-sha1
+  as modern OpenSSH versions reject this by default as it is unsafe.
+
 - `sftp_command` (string) - The command to run on the machine being
    provisioned by Packer to handle the SFTP protocol that Ansible will use to
    transfer files. The command should read and write on stdin and stdout,

--- a/provisioner/ansible/provisioner.hcl2spec.go
+++ b/provisioner/ansible/provisioner.hcl2spec.go
@@ -30,6 +30,7 @@ type FlatConfig struct {
 	LocalPort             *int              `mapstructure:"local_port" cty:"local_port" hcl:"local_port"`
 	SSHHostKeyFile        *string           `mapstructure:"ssh_host_key_file" cty:"ssh_host_key_file" hcl:"ssh_host_key_file"`
 	SSHAuthorizedKeyFile  *string           `mapstructure:"ssh_authorized_key_file" cty:"ssh_authorized_key_file" hcl:"ssh_authorized_key_file"`
+	AdapterKeyType        *string           `mapstructure:"ansible_proxy_key_type" cty:"ansible_proxy_key_type" hcl:"ansible_proxy_key_type"`
 	SFTPCmd               *string           `mapstructure:"sftp_command" cty:"sftp_command" hcl:"sftp_command"`
 	SkipVersionCheck      *bool             `mapstructure:"skip_version_check" cty:"skip_version_check" hcl:"skip_version_check"`
 	UseSFTP               *bool             `mapstructure:"use_sftp" cty:"use_sftp" hcl:"use_sftp"`
@@ -78,6 +79,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"local_port":                 &hcldec.AttrSpec{Name: "local_port", Type: cty.Number, Required: false},
 		"ssh_host_key_file":          &hcldec.AttrSpec{Name: "ssh_host_key_file", Type: cty.String, Required: false},
 		"ssh_authorized_key_file":    &hcldec.AttrSpec{Name: "ssh_authorized_key_file", Type: cty.String, Required: false},
+		"ansible_proxy_key_type":     &hcldec.AttrSpec{Name: "ansible_proxy_key_type", Type: cty.String, Required: false},
 		"sftp_command":               &hcldec.AttrSpec{Name: "sftp_command", Type: cty.String, Required: false},
 		"skip_version_check":         &hcldec.AttrSpec{Name: "skip_version_check", Type: cty.Bool, Required: false},
 		"use_sftp":                   &hcldec.AttrSpec{Name: "use_sftp", Type: cty.Bool, Required: false},


### PR DESCRIPTION
When using RSA keys, for some obscure reason, the SSH connection only accepts rsa-sha1 as the signature algorithm for the key, which is now unsupported in modern OpenSSH versions.

This causes problems when using Ansible in conjunction with the proxy adapter (the default), as Ansible uses `ssh' to connect, and in turn, rejects the connection unless users manually change their config to support this, or if they add extra options to Ansible in their templates to accept these insecure methods.

To fix this, we move to ECDSA keys for the Ansible adapter. We considered using ED25519, but these keys are only supported by SSH when using the native serialisation format, and not any of the PKCS variants, making it harder to serialise as we'd need to write our own serialisation method for this format, which is brittle at best.

Closes #69 

