### PR TITLE
Release 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     ansible = {
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
       source  = "github.com/hashicorp/ansible"
     }
   }

--- a/version/version.go
+++ b/version/version.go
@@ -7,12 +7,12 @@ import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.1.0"
+	Version = "1.1.1"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this
 	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = ""
+	VersionPrerelease = "dev"
 
 	// PluginVersion is used by the plugin set to allow Packer to recognize
 	// what version this plugin is.

--- a/version/version.go
+++ b/version/version.go
@@ -7,12 +7,12 @@ import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.0.5"
+	Version = "1.1.0"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this
 	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 
 	// PluginVersion is used by the plugin set to allow Packer to recognize
 	// what version this plugin is.


### PR DESCRIPTION
This is a minor bump because of the change from RSA to ECDSA for the adapter SSH keys we generate. This will likely be harmless for most users, but given that it might break some configs in legacy environments, we opt to minor bump this time.