### PR TITLE
Fix quoting of arguments passed through ansible_ssh_extra_args

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -838,7 +838,7 @@ func (p *Provisioner) createCmdArgs(httpAddr, inventory, playbook, privKeyFile s
 	if p.generatedData["ConnType"] == "ssh" && len(privKeyFile) > 0 {
 		// Add ssh extra args to set IdentitiesOnly
 		if len(p.config.AnsibleSSHExtraArgs) > 0 {
-			args = append(args, "--ssh-extra-args", fmt.Sprintf("'%s'", strings.Join(p.config.AnsibleSSHExtraArgs, " ")))
+			args = append(args, "--ssh-extra-args", fmt.Sprintf("'%s'", strings.Join(p.config.AnsibleSSHExtraArgs, "' '")))
 		} else {
 			args = append(args, "--ssh-extra-args", "'-o IdentitiesOnly=yes'")
 		}

--- a/provisioner/ansible/provisioner_test.go
+++ b/provisioner/ansible/provisioner_test.go
@@ -484,6 +484,18 @@ func TestCreateCmdArgs(t *testing.T) {
 			ExpectedEnvVars:     []string{"ENV_1=pancakes", "ENV_2=bananas"},
 		},
 		{
+			// SSH with private key and an extra argument and multiple ssh extra arguments.
+			TestName:            "SSH with private key and an extra argument and multiple ssh extra arguments",
+			PackerBuildName:     "packerparty",
+			generatedData:       basicGenData(nil),
+			ExtraArguments:      []string{"-e", "hello-world"},
+			AnsibleSSHExtraArgs: []string{"-o HostKeyAlgorithms=+ssh-rsa", "-o PubkeyAcceptedKeyTypes=+ssh-rsa", "-o IdentitiesOnly=no"},
+			AnsibleEnvVars:      []string{"ENV_1=pancakes", "ENV_2=bananas"},
+			callArgs:            []string{commonsteps.HttpAddrNotImplemented, "/var/inventory", "test-playbook.yml", "/path/to/privkey.pem"},
+			ExpectedArgs:        []string{"-e", "packer_build_name=\"packerparty\"", "-e", "packer_builder_type=fakebuilder", "--ssh-extra-args", "'-o HostKeyAlgorithms=+ssh-rsa' '-o PubkeyAcceptedKeyTypes=+ssh-rsa' '-o IdentitiesOnly=no'", "-e", "ansible_ssh_private_key_file=/path/to/privkey.pem", "-e", "hello-world", "-i", "/var/inventory", "test-playbook.yml"},
+			ExpectedEnvVars:     []string{"ENV_1=pancakes", "ENV_2=bananas"},
+		},
+		{
 			TestName:        "SSH with private key and an extra argument and UseProxy",
 			PackerBuildName: "packerparty",
 			UseProxy:        confighelper.TriTrue,


### PR DESCRIPTION
Fixes #158 by quoting individual arguments in the `ansible_ssh_extra_args` list instead of joining arguments and only quoting all of them together after.

Note that I kept the simple implementation of only putting arguments in quotes but ideally you'd probably want to consider using a dedicated library for joining arguments using sh's word-splitting rules such as [go-shellquote](https://github.com/kballard/go-shellquote).
