### PR TITLE
Set packer_http_addr of extra-vars as an empty string when it's nil

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -549,8 +549,12 @@ func (p *Provisioner) invokeGalaxyCommand(args []string, ui packersdk.Ui, comm p
 func (p *Provisioner) executeAnsible(ui packersdk.Ui, comm packersdk.Communicator) error {
 	inventory := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(p.config.InventoryFile)))
 
+	packerHTTPAddr := p.generatedData["PackerHTTPAddr"]
+	if packerHTTPAddr == nil {
+		packerHTTPAddr = ""
+	}
 	extraArgs := fmt.Sprintf(" --extra-vars \"packer_build_name=%s packer_builder_type=%s packer_http_addr=%s -o IdentitiesOnly=yes\" ",
-		p.config.PackerBuildName, p.config.PackerBuilderType, p.generatedData["PackerHTTPAddr"])
+		p.config.PackerBuildName, p.config.PackerBuilderType, packerHTTPAddr)
 	if len(p.config.ExtraArguments) > 0 {
 		extraArgs = extraArgs + strings.Join(p.config.ExtraArguments, " ")
 	}


### PR DESCRIPTION
Fixes #173. This fix involves examining the `generatedData` to determine if the `PackerHTTPAddr` is nil. If the `PackerHTTPAddr` is nil, set it as an empty string. This modification ensures the proper handling of the packer_http_addr variable within the ansible-local provisioner.

#### Test

1. Navigate to the source directory of Ansible-local.
2. Run the test cases as follows:
```
[ansible-local]$ go test
2023/09/13 14:38:13 ui: Provisioning with Ansible...
2023/09/13 14:38:13 ui: Creating Ansible staging directory...
2023/09/13 14:38:13 ui: Creating directory: /tmp/packer-provisioner-ansible-local/65013cb5-9e19-0c3d-9ee7-ca232dba2af5
2023/09/13 14:38:13 ui: Uploading playbook file: /tmp/2605838767
2023/09/13 14:38:13 ui: Creating directory: /tmp/packer-provisioner-ansible-local/65013cb5-9e19-0c3d-9ee7-ca232dba2af5/tmp
2023/09/13 14:38:13 ui: Uploading playbook file: /tmp/239453821
2023/09/13 14:38:13 ui: Creating directory: /tmp/packer-provisioner-ansible-local/65013cb5-9e19-0c3d-9ee7-ca232dba2af5/tmp
2023/09/13 14:38:13 ui: Uploading playbook file: /tmp/1305372664
2023/09/13 14:38:13 ui: Creating directory: /tmp/packer-provisioner-ansible-local/65013cb5-9e19-0c3d-9ee7-ca232dba2af5/tmp
2023/09/13 14:38:13 ui: Uploading inventory file...
2023/09/13 14:38:13 ui: Executing Ansible: cd /tmp/packer-provisioner-ansible-local/65013cb5-9e19-0c3d-9ee7-ca232dba2af5 &&  ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 ansible-playbook /tmp/packer-provisioner-ansible-local/65013cb5-9e19-0c3d-9ee7-ca232dba2af5/tmp/2605838767 --extra-vars "packer_build_name= packer_builder_type= packer_http_addr= -o IdentitiesOnly=yes"  -c local -i /tmp/packer-provisioner-ansible-local/65013cb5-9e19-0c3d-9ee7-ca232dba2af5/packer-provisioner-ansible-local1541997294
```
`packer_http_addr` should be an empty string, not `%!s(<nil>)`.

Closes #173

