### PR TITLE
add extra strings to sanitize

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -931,7 +931,9 @@ func (p *Provisioner) executeAnsible(ui packersdk.Ui, comm packersdk.Communicato
 			continue
 		}
 		if strings.Contains(strings.ToLower(args[0]), "password") ||
-			strings.Contains(strings.ToLower(args[0]), "secret") {
+			strings.Contains(strings.ToLower(args[0]), "secret") ||
+			strings.Contains(strings.ToLower(args[0]), "token") ||
+			strings.Contains(strings.ToLower(args[0]), "key") {
 			sanitized = strings.Replace(sanitized,
 				args[1], "*****", -1)
 		}


### PR DESCRIPTION
Base on the documentation of the use of the plugin, there is a need to add other keywords to sanitize in the log output

<img width="915" alt="Screenshot 2024-07-02 at 1 32 39 PM" src="https://github.com/hashicorp/packer-plugin-ansible/assets/3172378/b5812740-ec3f-4652-81cf-70a8ffb6b41d">
