### PR TITLE
Update Ansible docs with latest repo name

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ packer {
   required_plugins {
     ansible = {
       version = "~> 1"
-      source = "github.com/hashicorp/ansible"
+      source = "github.com/hashicorp/packer-plugin-ansible"
     }
   }
 }
@@ -18,7 +18,7 @@ packer {
 Alternatively, you can use `packer plugins install` to manage installation of this plugin.
 
 ```sh
-packer plugins install github.com/hashicorp/ansible
+packer plugins install github.com/hashicorp/packer-plugin-ansible
 ```
 
 ### Components


### PR DESCRIPTION
Updating hashicorp/ansible to hashicorp/packer-plugin-ansible repo name. 