### PR TITLE
Update ansible script link to configure remoting for ansible

### DIFF
--- a/docs/provisioners/ansible.mdx
+++ b/docs/provisioners/ansible.mdx
@@ -219,7 +219,7 @@ There are two possible methods for using Ansible with the WinRM communicator.
 Please note that if you're having trouble getting Ansible to connect, you may
 want to take a look at the script that the Ansible project provides to help
 configure remoting for Ansible:
-https://github.com/ansible/ansible/blob/devel/examples/scripts/ConfigureRemotingForAnsible.ps1
+https://github.com/ansible/ansible-documentation/blob/devel/examples/scripts/ConfigureRemotingForAnsible.ps1
 
 #### Method 1 (recommended)
 


### PR DESCRIPTION
**Description**: 

I am updating a broken link in the ansible plugin documentation
current link - https://github.com/ansible/ansible/blob/devel/examples/scripts/ConfigureRemotingForAnsible.ps1
new link - https://github.com/ansible/ansible-documentation/blob/devel/examples/scripts/ConfigureRemotingForAnsible.ps1

