### PR TITLE
handle missing or invalid Host IP gracefully in provisioner

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -611,8 +611,8 @@ func (p *Provisioner) Provision(ctx context.Context, ui packersdk.Ui, comm packe
 
 	// Set up proxy if host IP is missing or communicator type is wrong.
 	if p.config.UseProxy.False() {
-		hostIP := generatedData["Host"].(string)
-		if hostIP == "" {
+		hostIP, ok := generatedData["Host"].(string)
+		if !ok || hostIP == "" {
 			ui.Error("Warning: use_proxy is false, but instance does" +
 				" not have an IP address to give to Ansible. Falling back" +
 				" to use localhost proxy.")


### PR DESCRIPTION
### Description
Handled the case where the Host IP isn't set in the case of builders like lxc, etc. 

This caused the plugin to crash with a panic. With this change the crash is handled. Issue reported in #204 

