### PR TITLE
Fix branch name in metadata.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,6 @@ jobs:
         with:
           version: ${{ needs.set-product-version.outputs.product-version }}
           product: ${{ env.REPO_NAME }}
-          branch: ${{ github.ref_name }}
 
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:


### PR DESCRIPTION
### Description
Removed the branch argument while calling the generate metadata.json file. The branch name in the output file comes out blank when this is passed.

