### PR TITLE
Fixed api_version not set in the binary name in artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,8 @@ jobs:
   plugin-check:
     needs: get-go-version
     runs-on: ubuntu-latest
+    outputs:
+      api_version: ${{ steps.plugin_describe.outputs.api_version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Unshallow
@@ -135,7 +137,7 @@ jobs:
           CGO_ENABLED: "0"
         uses: hashicorp/actions-go-build@v1
         with:
-          bin_name: ${{ env.REPO_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_v${{ steps.plugin_describe.outputs.api_version }}_${{ matrix.goos }}_${{ matrix.goarch }}
+          bin_name: ${{ env.REPO_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_v${{ needs.plugin-check.outputs.api_version }}_${{ matrix.goos }}_${{ matrix.goarch }}
           product_name: ${{ env.REPO_NAME }}
           product_version: ${{ needs.set-product-version.outputs.product-version }}
           go_version: ${{ matrix.go }}
@@ -171,7 +173,7 @@ jobs:
           CGO_ENABLED: "0"
         uses: hashicorp/actions-go-build@v1
         with:
-          bin_name: ${{ env.REPO_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_v${{ steps.plugin_describe.outputs.api_version }}_${{ matrix.goos }}_${{ matrix.goarch }}
+          bin_name: ${{ env.REPO_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_v${{ needs.plugin-check.outputs.api_version }}_${{ matrix.goos }}_${{ matrix.goarch }}
           product_name: ${{ env.REPO_NAME }}
           product_version: ${{ needs.set-product-version.outputs.product-version }}
           go_version: ${{ matrix.go }}
@@ -206,7 +208,7 @@ jobs:
           CGO_ENABLED: "0"
         uses: hashicorp/actions-go-build@v1
         with:
-          bin_name: ${{ env.REPO_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_v${{ steps.plugin_describe.outputs.api_version }}_${{ matrix.goos }}_${{ matrix.goarch }}
+          bin_name: ${{ env.REPO_NAME }}_v${{ needs.set-product-version.outputs.product-version }}_v${{ needs.plugin-check.outputs.api_version }}_${{ matrix.goos }}_${{ matrix.goarch }}
           product_name: ${{ env.REPO_NAME }}
           product_version: ${{ needs.set-product-version.outputs.product-version }}
           go_version: ${{ matrix.go }}


### PR DESCRIPTION
### Description
The api_version was not set as output of the plugin-check job which resulted in missing version in binary name.

