### PR TITLE
Add manifest json file during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,3 +218,27 @@ jobs:
           instructions: |-
             cp LICENSE "$TARGET_DIR/LICENSE.txt"
             go build -o "$BIN_PATH" -ldflags="$LD_FLAGS" -trimpath -buildvcs=false
+
+  upload-manifest-json:
+    needs:
+      - set-product-version
+      - plugin-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: create-manifest-json
+        id: create-manifest-json
+        run: |
+          cat > ${{ env.REPO_NAME }}_${{ needs.set-product-version.outputs.product-version }}_manifest.json << EOF
+          {
+            "version": "${{ needs.set-product-version.outputs.product-version }}",
+            "metadata": {
+              "protocol_version": "${{ needs.plugin-check.outputs.api_version }}"
+            }
+          }
+          EOF
+      - name: Upload manifest json
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: packer-plugin-manifest.json
+          path: ${{ env.REPO_NAME }}_${{ needs.set-product-version.outputs.product-version }}_manifest.json


### PR DESCRIPTION
### Description
Added a job to create and upload manifest.json file during build
This json file stores the API version used by the plugin since the api_version was stripped from the zip filename This helps in determining the right plugin version during installation


