### PR TITLE
remove illumos os from builds (#235)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [ freebsd, windows, netbsd, openbsd, solaris, illumos ]
+        goos: [ freebsd, windows, netbsd, openbsd, solaris ]
         goarch: [ "386", "amd64", "arm"]
         go: [ "${{ needs.get-go-version.outputs.go-version }}" ]
         exclude:
@@ -119,10 +119,6 @@ jobs:
             goarch: arm
           - goos: windows
             goarch: arm
-          - goos: illumos
-            goarch: arm
-          - goos: illumos
-            goarch: 386
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build

--- a/.release/packer-plugin-ansible-artifacts.hcl
+++ b/.release/packer-plugin-ansible-artifacts.hcl
@@ -13,7 +13,6 @@ artifacts {
     "packer-plugin-ansible_${version}_linux_amd64.zip",
     "packer-plugin-ansible_${version}_linux_arm.zip",
     "packer-plugin-ansible_${version}_linux_arm64.zip",
-    "packer-plugin-ansible_${version}_illumos_amd64.zip",
     "packer-plugin-ansible_${version}_netbsd_386.zip",
     "packer-plugin-ansible_${version}_netbsd_amd64.zip",
     "packer-plugin-ansible_${version}_netbsd_arm.zip",


### PR DESCRIPTION
### Description
What code changed, and why?
Packer isn't released with illumos os type, hence
removing from plugins build


